### PR TITLE
Add scale_colour_continuous example

### DIFF
--- a/man/geom_pointdensity.Rd
+++ b/man/geom_pointdensity.Rd
@@ -99,6 +99,10 @@ ggplot(data = dat, mapping = aes(x = x, y = y)) +
 ggplot(data = dat, mapping = aes(x = x, y = y)) +
   geom_pointdensity(adjust = 4)
 
+ggplot(data = dat, mapping = aes(x = x, y = y)) +
+  geom_pointdensity(adjust = 4) +
+  scale_colour_continuous(low = "red", high = "black")
+
 # I recommend the viridis package
 # for a more useful color scale
 library(viridis)


### PR DESCRIPTION
It wasn't immediately obvious to me that you could in fact use the standard `scale_colour_*` functions so I just added a simple example. The focus being on `scale_colour_virdis` made me initially think I _had_ to use that package for some reason.